### PR TITLE
Armor Equip and Event Handling Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The events handle when a player
         <li>Hotswap with hotbar(1-9) or with second hand(F)</li>
         <li>Dragged item</li>
     </ul>
-    <li>Equip item through hotbar right-click</li>
+    <li>Equip/Swap item through hotbar right-click</li>
     <li>Equip item by Dispenser</li>
     <li>Unequip when Player dies</li>
     <li>Unequip when armor item breaks</li>

--- a/src/main/java/de/unpixelt/armorchange/ArmorEquipEvent.java
+++ b/src/main/java/de/unpixelt/armorchange/ArmorEquipEvent.java
@@ -1,6 +1,5 @@
 package de.unpixelt.armorchange;
 
-import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.EquipmentSlot;
@@ -15,12 +14,12 @@ public class ArmorEquipEvent extends ArmorEvent {
     private static final HandlerList HANDLERS = new HandlerList();
 
     protected ArmorEquipEvent(@NotNull final Player who, @NotNull final ItemStack item,
-                              @NotNull final EquipmentSlot slot, @NotNull final ArmorAction action) {
+            @NotNull final EquipmentSlot slot, @NotNull final ArmorAction action) {
         super(who, item, slot, action);
     }
 
     public ArmorEquipEvent(@NotNull final Player who, @NotNull final ItemStack item,
-                           @NotNull final EquipmentSlot slot) {
+            @NotNull final EquipmentSlot slot) {
         this(who, item, slot, ArmorAction.CUSTOM);
     }
 

--- a/src/main/java/de/unpixelt/armorchange/ArmorEvent.java
+++ b/src/main/java/de/unpixelt/armorchange/ArmorEvent.java
@@ -1,6 +1,5 @@
 package de.unpixelt.armorchange;
 
-import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
@@ -22,7 +21,7 @@ public abstract class ArmorEvent extends Event implements Cancellable {
     private final ArmorAction action;
 
     public ArmorEvent(@NotNull final Player who, @NotNull final ItemStack item,
-                      @NotNull final EquipmentSlot slot, @NotNull final ArmorAction action) {
+            @NotNull final EquipmentSlot slot, @NotNull final ArmorAction action) {
         this.who = who;
         this.item = item;
         this.slot = slot;
@@ -95,7 +94,7 @@ public abstract class ArmorEvent extends Event implements Cancellable {
 
     /**
      * Gets whether this event is cancelled. This is based off of the
-     * Result value returned by {@link #getResult()}.  Result.ALLOW and
+     * Result value returned by {@link #getResult()}. Result.ALLOW and
      * Result.DEFAULT will result in a returned value of false, but
      * Result.DENY will result in a returned value of true.
      * <p>
@@ -129,7 +128,8 @@ public abstract class ArmorEvent extends Event implements Cancellable {
      * @param toCancel The cancellable event to update.
      */
     protected void updateCancellable(@NotNull Cancellable toCancel) {
-        toCancel.setCancelled(isCancelled());
+        if (isCancelled())
+            toCancel.setCancelled(true);
     }
 
     public enum ArmorAction {


### PR DESCRIPTION
# ArmorEvent.java
Changes are made so that if `toCancel` has already been canceled, the process is not undone.
# ArmorListener.java
## Version Checking
A static block was added to calculate and store a `CAN_SWAP` flag based on the Minecraft version (major, minor, patch). This flag checks if the current Minecraft version supports armor swapping (version >= 1.19.4).
## Player Interact Event
Improved handling of armor equipping when a player right-clicks with an armor item. If the player’s current armor slot is empty or can be swapped (based on the `CAN_SWAP` flag), the appropriate `callEquip` or `callUnequip` method is triggered.

# Overall
- the IDE has made some formatting changes (sorry for that)
- Version compatibility (armor swapping) was added for Minecraft versions 1.19.4 and above.